### PR TITLE
Add test for int64 (type 'h') and add workaround for lua < 5.3

### DIFF
--- a/.luacov
+++ b/.luacov
@@ -1,7 +1,9 @@
 include = {
-  'src'
+  'src%/losc$',
+  'src%/losc%/.+$',
+  'src%/losc%/plugins%/.+$',
 }
 exclude = {
   'src/losc/lib/.+$',
-  'src/losc/serializer'
+  'src/losc/serializer',
 }

--- a/spec/types/double_spec.lua
+++ b/spec/types/double_spec.lua
@@ -39,3 +39,56 @@ describe('double', function()
     end)
   end)
 end)
+
+-- https://github.com/iryont/lua-struct/issues/3
+-- lua < 5.3 will truncate the value to a signed 32-bit integer.
+describe('int64', function()
+  local data, expected_bytes
+  local value = 9223372036854775807
+  if string.pack then
+    expected_bytes = {127, 255, 255, 255, 255, 255, 255, 255}
+  else
+    expected_bytes = {127, 255, 255, 255}
+  end
+
+  describe('pack', function()
+    setup(function()
+      data = Types.pack.h(value)
+    end)
+
+    it('returns the correct byte representation', function()
+      local bytes = {string.byte(data, 1, -1)}
+      for i, byte in ipairs(bytes) do
+        assert.are.equal(expected_bytes[i], byte)
+      end
+    end)
+
+    it('returns a multiple of 32', function()
+      assert.are.equal(#data * 8 % 32, 0)
+    end)
+  end)
+
+  describe('unpack', function()
+    local h, offset
+
+    setup(function()
+      h, offset = Types.unpack.h(data)
+    end)
+
+    it('returns the correct offset', function()
+      if string.pack then
+        assert.are.equal(offset, 9)
+      else
+        assert.are.equal(offset, 5)
+      end
+    end)
+
+    it('returns the correct value', function()
+      if string.pack then
+        assert.are.equal(value, h)
+      else
+        assert.are.equal(2147483647, h)
+      end
+    end)
+  end)
+end)

--- a/src/losc/types.lua
+++ b/src/losc/types.lua
@@ -162,21 +162,38 @@ end
 --- Extended types.
 -- @section extended-types
 
---- 64 bit big-endian two's complement integer
+--- 64 bit big-endian two's complement integer.
+--
+-- WARNING This type is only supported for lua >= 5.3.
+-- versions < 5.3 versions will truncate the value to a signed 32-bit integer.
 -- @param value The value to pack.
 -- @return Binary string buffer.
 Types.pack.h = function(value)
-  local fmt = has_string_pack and '>i8' or '>l'
-  return _pack(fmt, value)
+  if has_string_pack then
+    return _pack('>i8', value)
+  else
+    if value > 2147483647 then
+      value = 2147483647
+    elseif value < -2147483648 then
+      value = -2147483648
+    end
+    return _pack('>i4', value)
+  end
 end
 
---- 64 bit big-endian two's complement integer
+--- 64 bit big-endian two's complement integer.
+--
+-- WARNING This type is only supported for lua >= 5.3.
+-- versions < 5.3 versions will truncate the value to a signed 32-bit integer.
 -- @param data The data to unpack.
 -- @param[opt] offset Initial offset into data.
 -- @return value, index of the bytes read + 1.
 Types.unpack.h = function(data, offset)
-  local fmt = has_string_pack and '>i8' or '>l'
-  return _unpack(fmt, data, offset)
+  if has_string_pack then
+    return _unpack('>i8', data, offset)
+  else
+    return _unpack('>i4', data, offset)
+  end
 end
 
 --- Timetag (64-bit integer divided into upper and lower part)


### PR DESCRIPTION
Lua < 5.3 cannot properly express 64-bit integers see this issue: https://github.com/iryont/lua-struct/issues/3