### PR TITLE
WIP: Add non-blocking mode

### DIFF
--- a/examples/server-nonblocking.lua
+++ b/examples/server-nonblocking.lua
@@ -1,0 +1,40 @@
+-- REMOVE NEXT LINE BEFORE MERGING
+package.path = ';./src/?/init.lua;./src/?.lua;/usr/local/share/lua/5.1/?.lua'
+
+local losc = require'losc'
+local plugin = require'losc.plugins.udp-socket'
+
+local udp = plugin.new {
+  recvAddr = 'localhost',
+  recvPort = 9000,
+  non_blocking = true, -- do not block on :open(), :poll() handles processing
+  ignore_late = true, -- ignore late bundles
+}
+local osc = losc.new {plugin = udp}
+
+local function print_data(data)
+  local msg = data.message
+  print('address: ' .. msg.address, 'timestamp: ' .. data.timestamp)
+  for index, argument in ipairs(msg) do
+    print('index: ' .. index, 'arg: ' .. argument)
+  end
+end
+
+osc:add_handler('/test', function(data)
+  print_data(data)
+end)
+
+osc:add_handler('/param/{x,y,z}', function(data)
+  print_data(data)
+end)
+
+osc:open() -- non blocking call :)
+
+local i = 0
+
+while true do
+    print("Loop iteration " .. i)
+    require'socket'.select(nil, nil, 2) -- equivalent for sleep() to simulate other tasks
+    osc:poll()
+    i = i + 1
+end

--- a/rockspecs/losc-scm-0.rockspec
+++ b/rockspecs/losc-scm-0.rockspec
@@ -1,7 +1,7 @@
 package = "losc"
 version = "scm-0"
 source = {
-   url = "git+https://github.com/davidgranstrom/losc.git"
+   url = "git+https://github.com/Simon-L/losc.git"
 }
 description = {
    summary = "OSC 1.0 library.",

--- a/src/losc/init.lua
+++ b/src/losc/init.lua
@@ -158,6 +158,13 @@ function losc:open(...)
   return pcall(self.plugin.open, self.plugin, ...)
 end
 
+function losc:poll(...)
+  if not self.plugin then
+    error('"poll" must be implemented using a plugin.')
+  end
+  return pcall(self.plugin.poll, self.plugin, ...)
+end
+
 --- Closes an OSC server.
 -- @param[opt] ... Plugin specific arguments.
 -- @return status, nil or error


### PR DESCRIPTION
**Please do not merge as is :)**

Related to #33 and #32
Attempted to add necessary methods for non-blocking, as far as I can tell this is working.

Basically it sets a timeout on receive so poll() just returns and other things can happen inbetween polling for new messages, what do you think? I haven't checked using other plugins with these changes.

Note that the new example has a temporary line to run from the source repo and bypas globally installed losc